### PR TITLE
Properties File Wizard

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -25,41 +25,6 @@
 		</repository>
 	</repositories>
 
-	<build>
-		<plugins>
-			<plugin>
-				<!-- Build an executable JAR -->
-				<groupId>org.apache.maven.plugins</groupId>
-				<artifactId>maven-jar-plugin</artifactId>
-				<version>2.4</version>
-				<configuration>
-					<archive>
-						<manifest>
-							<mainClass>com.glacier.discordbot.App</mainClass>
-						</manifest>
-					</archive>
-				</configuration>
-			</plugin>
-			<!-- any other plugins -->
-			<plugin>
-				<artifactId>maven-assembly-plugin</artifactId>
-				<executions>
-					<execution>
-						<phase>package</phase>
-						<goals>
-							<goal>single</goal>
-						</goals>
-					</execution>
-				</executions>
-				<configuration>
-					<descriptorRefs>
-						<descriptorRef>jar-with-dependencies</descriptorRef>
-					</descriptorRefs>
-				</configuration>
-			</plugin>
-		</plugins>
-	</build>
-
 	<dependencies>
 		<!-- https://mvnrepository.com/artifact/com.google.apis/google-api-services-youtube -->
 		<dependency>

--- a/src/main/java/com/glacier/discordbot/util/ProjectFileCreator.java
+++ b/src/main/java/com/glacier/discordbot/util/ProjectFileCreator.java
@@ -1,7 +1,21 @@
 package com.glacier.discordbot.util;
  
+import java.io.File;
+import java.io.FileNotFoundException;
+import java.io.IOException;
+import java.io.PrintWriter;
+
 import javafx.application.Application;
+import javafx.beans.value.ChangeListener;
+import javafx.beans.value.ObservableValue;
+import javafx.event.ActionEvent;
+import javafx.event.EventHandler;
 import javafx.scene.Scene;
+import javafx.scene.control.Button;
+import javafx.scene.control.TextField;
+import javafx.scene.input.KeyCode;
+import javafx.scene.input.KeyEvent;
+import javafx.scene.layout.HBox;
 import javafx.scene.layout.VBox;
 import javafx.scene.text.Text;
 import javafx.stage.Stage;
@@ -10,11 +24,133 @@ public class ProjectFileCreator extends Application {
 	@Override
 	public void start(Stage primaryStage)
 	{
-		VBox vbox = new VBox();
-		Text text = new Text("Hi hello I am a neat new file creator for you");
-		vbox.getChildren().add(text);
-		Scene primaryScene = new Scene(vbox,UtilsAndConstants.MENU_SIZE, UtilsAndConstants.MENU_SIZE_TWO);
+		HBox container = new HBox();
+		VBox inputs = new VBox();
+		HBox youtubeAPIKeyHolder = new HBox();
+		HBox youtubeChannelIDHolder = new HBox();
+		HBox discordTokenHolder = new HBox();
+		Text APIKeyLabel = new Text("Youtube API key:");
+		Text channelIDLabel = new Text("Youtube Channel ID:");
+		Text discordTokenLabel = new Text("Discord token:");
+		TextField APIKeyInput = new TextField();
+		TextField channelIDInput = new TextField();
+		TextField discordTokenInput = new TextField();
+		Button btBuild = new Button("Build me a properties file!");
+		youtubeAPIKeyHolder.getChildren().addAll(APIKeyLabel,APIKeyInput);
+		youtubeChannelIDHolder.getChildren().addAll(channelIDLabel,channelIDInput);
+		discordTokenHolder.getChildren().addAll(discordTokenLabel,discordTokenInput);
+		APIKeyInput.textProperty().addListener(new ChangeListener<String>() {
+            @Override
+            public void changed(ObservableValue<? extends String> obs, String previous, String newThing) {
+            	btBuild.setOnAction(new BuildFile(APIKeyInput.getText(),channelIDInput.getText(),discordTokenInput.getText()));
+            	APIKeyInput.setOnKeyPressed(new ButtonHandler(APIKeyInput.getText(),channelIDInput.getText(),discordTokenInput.getText()));
+            	channelIDInput.setOnKeyPressed(new ButtonHandler(APIKeyInput.getText(),channelIDInput.getText(),discordTokenInput.getText()));
+            	discordTokenInput.setOnKeyPressed(new ButtonHandler(APIKeyInput.getText(),channelIDInput.getText(),discordTokenInput.getText()));
+            	System.gc();
+            	//call garbage collection to make sure we don't make too many instances of the BuildFile and ButtonHandler class
+            }
+        });
+		channelIDInput.textProperty().addListener(new ChangeListener<String>() {
+            @Override
+            public void changed(ObservableValue<? extends String> obs, String previous, String newThing) {
+            	btBuild.setOnAction(new BuildFile(APIKeyInput.getText(),channelIDInput.getText(),discordTokenInput.getText()));
+            	APIKeyInput.setOnKeyPressed(new ButtonHandler(APIKeyInput.getText(),channelIDInput.getText(),discordTokenInput.getText()));
+            	channelIDInput.setOnKeyPressed(new ButtonHandler(APIKeyInput.getText(),channelIDInput.getText(),discordTokenInput.getText()));
+            	discordTokenInput.setOnKeyPressed(new ButtonHandler(APIKeyInput.getText(),channelIDInput.getText(),discordTokenInput.getText()));
+            	System.gc();
+            	//call garbage collection to make sure we don't make too many instances of the BuildFile and ButtonHandler class
+            }
+        });
+		discordTokenInput.textProperty().addListener(new ChangeListener<String>() {
+            @Override
+            public void changed(ObservableValue<? extends String> obs, String previous, String newThing) {
+            	btBuild.setOnAction(new BuildFile(APIKeyInput.getText(),channelIDInput.getText(),discordTokenInput.getText()));
+            	APIKeyInput.setOnKeyPressed(new ButtonHandler(APIKeyInput.getText(),channelIDInput.getText(),discordTokenInput.getText()));
+            	channelIDInput.setOnKeyPressed(new ButtonHandler(APIKeyInput.getText(),channelIDInput.getText(),discordTokenInput.getText()));
+            	discordTokenInput.setOnKeyPressed(new ButtonHandler(APIKeyInput.getText(),channelIDInput.getText(),discordTokenInput.getText()));
+            	System.gc();
+            	//call garbage collection to make sure we don't make too many instances of the BuildFile and ButtonHandler class
+            }
+        });
+		//every time a change is made to the textfields where the user can make input,
+		//pass that change in text along to the actual handlers to work with
+		btBuild.pressedProperty().addListener(new ChangeListener<Boolean>() {
+            @Override
+            public void changed(ObservableValue<? extends Boolean> obs, Boolean previous, Boolean newThing) {
+            	btBuild.setOnAction(new BuildFile(APIKeyInput.getText(),channelIDInput.getText(),discordTokenInput.getText()));
+            	APIKeyInput.setOnKeyPressed(new ButtonHandler(APIKeyInput.getText(),channelIDInput.getText(),discordTokenInput.getText()));
+            	channelIDInput.setOnKeyPressed(new ButtonHandler(APIKeyInput.getText(),channelIDInput.getText(),discordTokenInput.getText()));
+            	discordTokenInput.setOnKeyPressed(new ButtonHandler(APIKeyInput.getText(),channelIDInput.getText(),discordTokenInput.getText()));
+            	System.gc();
+            	//call garbage collection to make sure we don't make too many instances of the BuildFile and ButtonHandler class
+            }
+        });
+		//just in case, when the button is pressed, update the text fields, even though that shouldn't really have to happen
+		btBuild.setOnAction(new BuildFile(APIKeyInput.getText(),channelIDInput.getText(),discordTokenInput.getText()));
+		inputs.getChildren().addAll(youtubeAPIKeyHolder,youtubeChannelIDHolder,discordTokenHolder);
+		container.getChildren().addAll(inputs,btBuild);
+		Scene primaryScene = new Scene(container,UtilsAndConstants.MENU_SIZE, UtilsAndConstants.MENU_SIZE_TWO);
 		primaryStage.setScene(primaryScene);
 		primaryStage.show();
 	}
+}
+
+class BuildFile implements EventHandler<ActionEvent>
+{
+
+	String APIKey;
+	String channelID;
+	String discordToken;
+
+	public BuildFile(String APIKey, String channelID, String discordToken)
+	{
+		this.APIKey = APIKey;
+		this.channelID = channelID;
+		this.discordToken = discordToken;
+	}
+	
+	@Override
+	public void handle(ActionEvent arg0) {
+		File discordProperties = new File("discordbot.properties");
+		try {
+			discordProperties.createNewFile();
+			PrintWriter writeThings = new PrintWriter(discordProperties);
+			writeThings.println("youtube.apikey="+APIKey);
+			writeThings.println("youtube.channelid="+channelID);
+			writeThings.println("discord.key="+discordToken);
+			writeThings.close();
+		} catch (FileNotFoundException e) {
+			// TODO Auto-generated catch block
+			e.printStackTrace();
+		} catch (IOException e) {
+			// TODO Auto-generated catch block
+			e.printStackTrace();
+		}
+	}
+	
+}
+
+class ButtonHandler implements EventHandler<KeyEvent>
+{
+	
+	String APIKey;
+	String channelID;
+	String discordToken;
+
+	public ButtonHandler(String APIKey, String channelID, String discordToken)
+	{
+		this.APIKey = APIKey;
+		this.channelID = channelID;
+		this.discordToken = discordToken;
+	}
+	
+	@Override
+	public void handle(KeyEvent event) {
+		// TODO Auto-generated method stub
+		if(event.getCode() == KeyCode.ENTER)
+		{
+			new BuildFile(APIKey,channelID,discordToken).handle(new ActionEvent());
+		}
+	}
+	
 }

--- a/src/main/java/com/glacier/discordbot/util/ProjectFileCreator.java
+++ b/src/main/java/com/glacier/discordbot/util/ProjectFileCreator.java
@@ -1,0 +1,20 @@
+package com.glacier.discordbot.util;
+ 
+import javafx.application.Application;
+import javafx.scene.Scene;
+import javafx.scene.layout.VBox;
+import javafx.scene.text.Text;
+import javafx.stage.Stage;
+
+public class ProjectFileCreator extends Application {
+	@Override
+	public void start(Stage primaryStage)
+	{
+		VBox vbox = new VBox();
+		Text text = new Text("Hi hello I am a neat new file creator for you");
+		vbox.getChildren().add(text);
+		Scene primaryScene = new Scene(vbox,UtilsAndConstants.MENU_SIZE, UtilsAndConstants.MENU_SIZE_TWO);
+		primaryStage.setScene(primaryScene);
+		primaryStage.show();
+	}
+}

--- a/src/main/java/com/glacier/discordbot/util/ProjectFileCreator.java
+++ b/src/main/java/com/glacier/discordbot/util/ProjectFileCreator.java
@@ -32,6 +32,7 @@ public class ProjectFileCreator extends Application {
 		Text APIKeyLabel = new Text("Youtube API key:");
 		Text channelIDLabel = new Text("Youtube Channel ID:");
 		Text discordTokenLabel = new Text("Discord token:");
+		Text message = new Text("Close me after you've hit the button, and try again");
 		TextField APIKeyInput = new TextField();
 		TextField channelIDInput = new TextField();
 		TextField discordTokenInput = new TextField();
@@ -87,7 +88,7 @@ public class ProjectFileCreator extends Application {
         });
 		//just in case, when the button is pressed, update the text fields, even though that shouldn't really have to happen
 		btBuild.setOnAction(new BuildFile(APIKeyInput.getText(),channelIDInput.getText(),discordTokenInput.getText()));
-		inputs.getChildren().addAll(youtubeAPIKeyHolder,youtubeChannelIDHolder,discordTokenHolder);
+		inputs.getChildren().addAll(youtubeAPIKeyHolder,youtubeChannelIDHolder,discordTokenHolder,message);
 		container.getChildren().addAll(inputs,btBuild);
 		Scene primaryScene = new Scene(container,UtilsAndConstants.MENU_SIZE, UtilsAndConstants.MENU_SIZE_TWO);
 		primaryStage.setScene(primaryScene);

--- a/src/main/java/com/glacier/discordbot/util/UtilsAndConstants.java
+++ b/src/main/java/com/glacier/discordbot/util/UtilsAndConstants.java
@@ -29,8 +29,8 @@ public class UtilsAndConstants {
 	public static String BOT_PREFIX = "~";
 	private static final String PROPERTIES_FILENAME = "discordbot.properties";	
 	public static final String BEGINNING_PIECE_OF_URL = "http://www.youtube.com/watch?v=";
-	public static final double MENU_SIZE = 500;
-	public static final double MENU_SIZE_TWO = 500;
+	public static final double MENU_SIZE = 530;
+	public static final double MENU_SIZE_TWO = 145;
 	public static Properties properties = setupProperties();
 	public static int MAX_ITEMS_TO_FETCH = 5;
 	//public static Logger logger = LoggerFactory.getLogger(App.class);

--- a/src/main/java/com/glacier/discordbot/util/UtilsAndConstants.java
+++ b/src/main/java/com/glacier/discordbot/util/UtilsAndConstants.java
@@ -29,6 +29,8 @@ public class UtilsAndConstants {
 	public static String BOT_PREFIX = "~";
 	private static final String PROPERTIES_FILENAME = "discordbot.properties";	
 	public static final String BEGINNING_PIECE_OF_URL = "http://www.youtube.com/watch?v=";
+	public static final double MENU_SIZE = 500;
+	public static final double MENU_SIZE_TWO = 500;
 	public static Properties properties = setupProperties();
 	public static int MAX_ITEMS_TO_FETCH = 5;
 	//public static Logger logger = LoggerFactory.getLogger(App.class);
@@ -58,7 +60,9 @@ public class UtilsAndConstants {
         }
         catch(NullPointerException ex)
         {
-        	System.err.println("There's no properties file, check the read me, please!");
+        	System.err.println("There's no properties file available, launching interface to create it now.");
+        	String[] args = new String[0];
+        	ProjectFileCreator.launch(ProjectFileCreator.class,args);
         	return null;
         }
 	}


### PR DESCRIPTION
On trying to run the bot's packaged jar without the required properties file, the program should now bring up a little wizard that allows the user to generate the required properties file, in the required location, simply by inputting the three data items that are necessary for the program to function as intended. At this point, I'm going to close development on the bot, for now. I may eventually come back for the top 5 videos command, but that's going to require pulling in the Youtube Analytics API on top of the Youtube Data API. Because of this, I'll save this feature for another day. 